### PR TITLE
add stand-to-sit and sit-to-stand pos files

### DIFF
--- a/pos/sit-to-stand.pos
+++ b/pos/sit-to-stand.pos
@@ -1,0 +1,8 @@
+  HY    HP    LSP   LSR   LEY   LER   LWY   LHYP  LHR   LHP   LKP   LAP   LAR   RHR   RHP   RKP   RAP   RAR   RSP   RSR   REY   RER   RWY   LH    RH    DUR
+
+Turn stiffness on, raise arms forward so they dont get caught on the body
+$ 1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1
+! 0     0   	70    25    -92   -61   54    0     0     -50   125   -70   0     0     -50   125   -70   0     70    -25   92    61    -54   0     0     1000
+
+Stand up
+! 0     0     90    10    0     0     0     0     0     -25   50    -25   0     0     -25   50    -25   0     90    -10   0     0     0     0     0     2000

--- a/pos/stand-to-sit.pos
+++ b/pos/stand-to-sit.pos
@@ -1,0 +1,13 @@
+  HY    HP    LSP   LSR   LEY   LER   LWY   LHYP  LHR   LHP   LKP   LAP   LAR   RHR   RHP   RKP   RAP   RAR   RSP   RSR   REY   RER   RWY   LH    RH    DUR
+
+Sit with arms forward, so they dont get caught on the body
+$ 1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1     1
+! 0     0   	70    25    -92   -61   54    0     0     -50   125   -70   0     0     -50   125   -70   0     70    -25   92    61    -54   0     0     2000
+
+After crouching, hands on knees to avoid robot falling forward and face planting
+$ 0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2   0.2
+! 0     0   	72    2     -33   -47   55    0     0     -50   125   -70   0     0     -50   125   -70   0     72    -2    33    47    -55   0     0     1000
+
+Turn stiffness off
+$ 0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0     0
+! 0     0   	72    2     -33   -47   55    0     0     -50   125   -70   0     0     -50   125   -70   0     72    -2    33    47    -55   0     0     100


### PR DESCRIPTION
Adds two pos files:
* stand_to_sit.pos - Sits the robot down, then unstiffens.
* sit_to_stand.pos - Stiffens the robot, and stands up. Assumes robot is in sitting position.

These two pos files are useful during testing to prevent overheating the robot's joints.

Click to see video:
[![](https://img.youtube.com/vi/zy4xEHHjW2c/0.jpg)](https://youtu.be/zy4xEHHjW2c_)